### PR TITLE
network-playbook

### DIFF
--- a/network
+++ b/network
@@ -1,0 +1,56 @@
+---
+- hosts: all
+  gather_facts: no
+
+  vars:
+    commands:
+      - "show clock"
+      - "show version"
+      - "show interface"
+      - "show module"
+      - "show inventory"
+      - "show environment"
+      - "show interface counters errors"
+      - "show interface ethernet X/Y transceiver details" #X/Yは各leafのport番号 X=1,Y=6
+      - "show system internal ethpm event-history errors"
+      - "show system internal ethpm event-history module 1"
+      - "show system internal vpcm event-history errors"
+      - "show system internal vpcm event-history config debugs"
+      - "show ip route vrf all"
+      - "show endpoint detail"
+      - "show endpoint summary"
+      - "show interface status"
+      - "show vpc"
+      - "show port-channel summary"
+      - "show ip arp vrf all"
+      - "show system resources"
+      - "show interface ethernet X/Y" # 1/18の場合X=1,Y=18
+      - "show logging ip access-list internal packet-log deny"
+      - "show logging ip access-list cache deny"
+         
+    outfile_path: "/path/to/file/"
+    outfile_base: "filename"
+    outfile_ext: ".txt"
+
+  tasks:
+    - name: get timestamp hostname
+      command: date +'%Y%m%d-%H%M%S'_'hostname'.log 
+      register: timestamp
+
+    - name: run commands
+      block: #ディレクティブいらないかも・・・
+        - name: insert title #空白のtitleもいらないかも
+            raw: echo Exectuting "{{ item }}"
+        - name: execute
+            raw: "{{ item }}"
+        - name: insert blank line
+            raw: echo 
+      register: result
+      loop: "{{ commands }}"
+
+    - name: dump output from commands to a file
+      local_action:
+        module: copy
+        content: "{{ result | json_query('results[*].stdout_lines') | flatten | join('\n') }}"
+        dest: "{{ outfile_path }}/{{ outfile_base }}-{{ timestamp.stdout }}{{ outfile_ext }}"
+        force: yes


### PR DESCRIPTION
---
- hosts: all
  gather_facts: no

  vars:
    commands:
      - "show clock"
      - "show version"
      - "show interface"
      - "show module"
      - "show inventory"
      - "show environment"
      - "show interface counters errors"
      - "show interface ethernet X/Y transceiver details" #X/Yは各leafのport番号 X=1,Y=6
      - "show system internal ethpm event-history errors"
      - "show system internal ethpm event-history module 1"
      - "show system internal vpcm event-history errors"
      - "show system internal vpcm event-history config debugs"
      - "show ip route vrf all"
      - "show endpoint detail"
      - "show endpoint summary"
      - "show interface status"
      - "show vpc"
      - "show port-channel summary"
      - "show ip arp vrf all"
      - "show system resources"
      - "show interface ethernet X/Y" # 1/18の場合X=1,Y=18
      - "show logging ip access-list internal packet-log deny"
      - "show logging ip access-list cache deny"
         
    outfile_path: "/path/to/file/"
    outfile_base: "filename"
    outfile_ext: ".txt"

  tasks:
    - name: get timestamp hostname
      command: date +'%Y%m%d-%H%M%S'_'hostname'.log 
      register: timestamp

    - name: run commands
      raw: echo Exectuting "{{ item }}"
      raw: "{{ item }}"
      raw: echo 
      register: result
      loop: "{{ commands }}"

    - name: dump output from commands to a file
      local_action:
        module: copy
        content: "{{ result | json_query('results[*].stdout_lines') | flatten | join('\n') }}"
        dest: "{{ outfile_path }}/{{ outfile_base }}-{{ timestamp.stdout }}{{ outfile_ext }}"
        force: yes
